### PR TITLE
Add keystroke simulation functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Alt Control Panel is a Python-based remote control application designed for mana
 - **Screenshot Capture**:
   - Capture screenshots of Alt's desktop.
   - Automatically upload screenshots to a configured Discord webhook.
+- **Keystroke Simulation**:
+  - Send keystrokes to Alt directly from the control panel.
 
 ## Requirements
 
@@ -75,6 +77,7 @@ pip install flask flask-cors pillow requests
 - `/kill_task`: Kill tasks by name or PID.
 - `/screenshot`: Capture and upload screenshots.
 - `/run_file`: Execute files remotely.
+- `/keystroke`: Simulate keystrokes on Alt.
 
 ### 4. Control Panel Interface
 Use the web interface to:
@@ -82,6 +85,7 @@ Use the web interface to:
 - View and manage running tasks.
 - Execute terminal commands.
 - Request screenshots.
+- Send keystrokes to Alt.
 
 ## How It Works
 

--- a/alt.py
+++ b/alt.py
@@ -95,6 +95,26 @@ def display_message():
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
+@app.route('/keystroke', methods=['POST'])
+def keystroke():
+    try:
+        keys = request.json.get("keys")
+        if not keys:
+            return jsonify({"error": "No keys provided"}), 400
+
+        escaped_keys = keys.replace("'", "''")
+        ps_script = (
+            f"$wshell = New-Object -ComObject WScript.Shell; "
+            f"$wshell.SendKeys('{escaped_keys}')"
+        )
+        subprocess.run(
+            ["powershell", "-Command", ps_script],
+            creationflags=subprocess.CREATE_NO_WINDOW,
+        )
+        return jsonify({"message": "Keystrokes sent"}), 200
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
 @app.route('/video_feed')
 def video_feed():
     return Response(generate_frames(), mimetype='multipart/x-mixed-replace; boundary=frame')

--- a/controlPanel.py
+++ b/controlPanel.py
@@ -57,6 +57,12 @@ class ControlPanelApp:
         self.message_input.pack(pady=5)
         tk.Button(left_panel, text="Send Message", font=("Arial", 12), width=25, command=self.display_message).pack(pady=5)
 
+        # Keystroke section
+        tk.Label(left_panel, text="Send Keystrokes:", font=("Arial", 12), bg="#f0f0f0").pack(anchor="w", pady=(15, 0))
+        self.keystroke_entry = tk.Entry(left_panel, font=("Arial", 12), width=22)
+        self.keystroke_entry.pack(pady=5)
+        tk.Button(left_panel, text="Send Keystrokes", font=("Arial", 12), width=25, command=self.send_keystrokes).pack(pady=5)
+
         # Right Panel - Command & Output
         tk.Label(right_panel, text="Run Terminal Command:", font=("Arial", 12), bg="#f0f0f0").pack(anchor="w", pady=(0, 5))
         self.command_input = scrolledtext.ScrolledText(right_panel, width=80, height=6, font=("Arial", 12))
@@ -225,6 +231,20 @@ class ControlPanelApp:
             response = requests.post(f"http://{ip}:5000/display_message", json={"message": message})
             if response.ok:
                 self.status_label.config(text="Message sent to Alt successfully!", fg="green")
+            else:
+                self.error_label.config(text=f"Failed: {response.text}", fg="red")
+        except Exception as e:
+            self.error_label.config(text=f"Error: {e}", fg="red")
+
+    def send_keystrokes(self):
+        ip = self.get_ip()
+        keys = self.keystroke_entry.get().strip()
+        if not ip or not keys:
+            return
+        try:
+            response = requests.post(f"http://{ip}:5000/keystroke", json={"keys": keys})
+            if response.ok:
+                self.status_label.config(text="Keystrokes sent successfully!", fg="green")
             else:
                 self.error_label.config(text=f"Failed: {response.text}", fg="red")
         except Exception as e:


### PR DESCRIPTION
## Summary
- allow sending keystrokes to Alt via new `/keystroke` endpoint
- add corresponding control panel controls and helper method
- document keystroke support and new endpoint in README

## Testing
- `python -m py_compile alt.py controlPanel.py`

------
https://chatgpt.com/codex/tasks/task_e_6844df5638488322a26a2d8373f69cc3