### PR TITLE
Remove deprecated screenshot feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Alt Control Panel is a Python-based remote control application designed for managing a secondary computer (referred to as "Alt") over a network. It provides functionalities such as file management, task management, terminal command execution, and screenshot capture via a Flask web interface.
+Alt Control Panel is a Python-based remote control application designed for managing a secondary computer (referred to as "Alt") over a network. It provides functionalities such as file management, task management, terminal command execution, and a live screen view via a Flask web interface.
 
 ## Features
 
@@ -17,14 +17,14 @@ Alt Control Panel is a Python-based remote control application designed for mana
   - View a list of all running tasks on Alt in a clean HTML table.
   - Kill specific tasks by name or PID (Process ID).
 
-- **Terminal Command Execution**:
+ - **Terminal Command Execution**:
   - Send commands to Alt's terminal remotely.
   - Receive output or error messages from executed commands.
 
-- **Screenshot Capture**:
-  - Capture screenshots of Alt's desktop.
-  - Automatically upload screenshots to a configured Discord webhook.
-- **Keystroke Simulation**:
+ - **Live Screen View**:
+  - View Alt's desktop in real time through the web interface.
+
+ - **Keystroke Simulation**:
   - Send keystrokes to Alt directly from the control panel using the Windows API.
   - System shortcuts like `Alt+Tab` work correctly for window switching.
   - Separate commands with commas to send them sequentially, e.g., `Alt+Tab, Alt+Tab`.
@@ -46,7 +46,7 @@ Alt Control Panel is a Python-based remote control application designed for mana
 3. **Python Dependencies**:
    - Flask
    - Flask-Cors
-   - Pillow (for screenshots)
+   - Pillow (for screen capture)
    - Requests
 
 Install these dependencies with:
@@ -87,7 +87,6 @@ pip install flask flask-cors pillow requests
 - `/run_command`: Execute terminal commands.
 - `/list_tasks`: View running tasks.
 - `/kill_task`: Kill tasks by name or PID.
-- `/screenshot`: Capture and upload screenshots.
 - `/run_file`: Execute files remotely.
 - `/keystroke`: Simulate keystrokes on Alt.
   - Use input like `Alt+Tab` to change windows remotely. System shortcuts are supported.
@@ -98,7 +97,6 @@ Use the web interface to:
 - Perform file operations.
 - View and manage running tasks.
 - Execute terminal commands.
-- Request screenshots.
 - Send keystrokes to Alt.
   - e.g., type `Alt+Tab` to switch windows using the native API.
 
@@ -107,7 +105,6 @@ Use the web interface to:
 
 1. **Web Interface**: The control panel provides an intuitive interface for sending commands to Alt.
 2. **Flask API**: Alt runs a Flask-based API server to process requests and perform tasks.
-3. **Discord Integration**: Screenshots are automatically sent to a Discord webhook for review.
 
 ## Example Commands
 

--- a/alt.py
+++ b/alt.py
@@ -3,7 +3,6 @@ import subprocess
 from flask import Flask, request, jsonify, send_from_directory, render_template_string, Response
 import os
 from PIL import ImageGrab
-import requests
 from flask_cors import CORS
 import time
 import cv2
@@ -13,7 +12,6 @@ import ctypes
 app = Flask(__name__)
 CORS(app, resources={r"/*": {"origins": "*", "methods": ["GET", "POST", "OPTIONS"], "allow_headers": "*"}})
 
-WEBHOOK_URL = "https://discord.com/api/webhooks/1314775003081871430/X3xBhkQ0K6ISb-mGpE4R-1yjfKlq-UEsdejT4CeF3RjBjcz5zGe-bGqq_wt_qtkWdj5x"
 BASE_DIRECTORY = os.path.expanduser("~")
 
 import tkinter as tk
@@ -269,28 +267,6 @@ def run_command():
         }), 200
     except Exception as e:
         return jsonify({"error": str(e)}), 500
-
-@app.route('/screenshot', methods=['POST'])
-def send_screenshot():
-    try:
-        downloads_dir = os.path.join(BASE_DIRECTORY, "Downloads")
-        os.makedirs(downloads_dir, exist_ok=True)
-
-        screenshot_path = os.path.join(downloads_dir, "screenshot.png")
-        screenshot = ImageGrab.grab()
-        screenshot.save(screenshot_path)
-
-        with open(screenshot_path, "rb") as f:
-            response = requests.post(WEBHOOK_URL, files={"file": f})
-
-        os.remove(screenshot_path)
-
-        if response.status_code == 200:
-            return "Screenshot sent successfully!"
-        else:
-            return f"Failed to send screenshot. Status code: {response.status_code}", 500
-    except Exception as e:
-        return f"Error capturing screenshot: {e}", 500
 
 
 @app.route('/files', methods=['GET', 'POST'])

--- a/controlPanel.py
+++ b/controlPanel.py
@@ -39,7 +39,6 @@ class ControlPanelApp:
         right_panel.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True, padx=10, pady=10)
 
         # Left Panel - Buttons and Inputs
-        tk.Button(left_panel, text="Request Screenshot", font=("Arial", 12), width=25, command=self.request_screenshot).pack(pady=5)
         tk.Button(left_panel, text="View Screen", font=("Arial", 12), width=25, command=self.view_screen).pack(pady=5)
         tk.Button(left_panel, text="Browse Files", font=("Arial", 12), width=25, command=self.browse_files).pack(pady=5)
         tk.Button(left_panel, text="List Tasks", font=("Arial", 12), width=25, command=self.list_tasks).pack(pady=5)
@@ -151,19 +150,6 @@ class ControlPanelApp:
             ip = selected.split(" ")[0]
             self.ip_entry.delete(0, tk.END)
             self.ip_entry.insert(0, ip)
-
-    def request_screenshot(self):
-        ip = self.get_ip()
-        if not ip:
-            return
-        try:
-            response = requests.post(f"http://{ip}:5000/screenshot")
-            if response.ok:
-                self.status_label.config(text="Screenshot request sent successfully!", fg="green")
-            else:
-                self.error_label.config(text=f"Failed: {response.text}", fg="red")
-        except Exception as e:
-            self.error_label.config(text=f"Error: {e}", fg="red")
 
     def browse_files(self):
         ip = self.get_ip()

--- a/controlPanelCLITool.py
+++ b/controlPanelCLITool.py
@@ -49,20 +49,6 @@ class ControlPanelCLI:
         self.ip = ip
         print(f"IP address set to {self.ip}")
 
-    def request_screenshot(self, ip=None):
-        ip = ip or self.ip
-        if not ip:
-            print("IP address is not set.")
-            return
-        try:
-            response = requests.post(f"http://{ip}:5000/screenshot")
-            if response.ok:
-                print(f"Screenshot request sent to {ip} successfully!")
-            else:
-                print(f"Error from {ip}: {response.text}")
-        except Exception as e:
-            print(f"Error: {e}")
-
     def browse_files(self, ip=None):
         ip = ip or self.ip
         if not ip:
@@ -126,12 +112,11 @@ if __name__ == "__main__":
         print("\nControl Panel CLI")
         print("1. Scan Network")
         print("2. Set IP Address")
-        print("3. Request Screenshot")
-        print("4. Browse Files")
-        print("5. List Tasks")
-        print("6. Run Command")
-        print("7. Display Message")
-        print("8. Exit")
+        print("3. Browse Files")
+        print("4. List Tasks")
+        print("5. Run Command")
+        print("6. Display Message")
+        print("7. Exit")
         choice = input("Select an option: ")
 
         if choice == "1":
@@ -142,18 +127,16 @@ if __name__ == "__main__":
             ip = input("Enter the IP address: ")
             app.set_ip(ip)
         elif choice == "3":
-            app.request_screenshot()
-        elif choice == "4":
             app.browse_files()
-        elif choice == "5":
+        elif choice == "4":
             app.list_tasks()
-        elif choice == "6":
+        elif choice == "5":
             command = input("Enter the command to run: ")
             app.run_command(command=command)
-        elif choice == "7":
+        elif choice == "6":
             message = input("Enter the message to display: ")
             app.display_message(message=message)
-        elif choice == "8":
+        elif choice == "7":
             print("Exiting...")
             break
         else:


### PR DESCRIPTION
## Summary
- remove screenshot request endpoint and webhook in `alt.py`
- drop screenshot button and method from GUI
- clean up CLI menu and screenshot function
- update documentation for live view

## Testing
- `python -m py_compile alt.py controlPanel.py controlPanelCLITool.py bootstrapper.py controlPanel.py alt.py`

------
https://chatgpt.com/codex/tasks/task_e_68450dc2cbd883228fa78c1222b5e85f